### PR TITLE
fix: use frontend friendly bundle instead of index export

### DIFF
--- a/lib/abnf.ts
+++ b/lib/abnf.ts
@@ -1,4 +1,5 @@
-import { apgApi, apgLib } from 'apg-js/dist/apg-api-bundle.js';
+import apgApi from 'apg-js/src/apg-api/api';
+import apgLib from 'apg-js/src/apg-lib/node-exports';
 
 const GRAMMAR = `
 sign-in-with-ethereum =

--- a/lib/abnf.ts
+++ b/lib/abnf.ts
@@ -1,4 +1,4 @@
-import { apgApi, apgLib } from 'apg-js';
+import { apgApi, apgLib } from 'apg-js/dist/apg-api-bundle.js';
 
 const GRAMMAR = `
 sign-in-with-ethereum =


### PR DESCRIPTION
Hi

Thanks for building an awesome library for logins with Ethereum 🙏 

I'm trying to use this library in a frontend Next.js application but I ran into errors saying it was trying to use the `fs` package, which is a Node.js only module.

Turns out that the way [apg-js](https://github.com/ldthomas/apg-js/blob/main/index.js) exports from the module index file loads `apg-conv`, which is a serverside only library relying on `fs`.

Luckily there's a frontend-friendly bundle that contains both `apgApi` and `apgLib` in the module dist folder, by using that we can support both frontend and backend usage without having to stub out `fs` 👍 