### PR TITLE
Add assets and docs folders to NPM's ignore list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 examples/
+assets/
+docs/
 favicon.svg
 jest.config.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siwe",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Sign-In with Ethereum",
   "main": "dist/siwe.js",
   "types": "dist/siwe.d.ts",


### PR DESCRIPTION
Remove assets and docs folders from the NPM package, reducing the package from 19mb to 87kb