### PR TITLE
Fix handling of messages with no statement

### DIFF
--- a/lib/abnf.ts
+++ b/lib/abnf.ts
@@ -26,7 +26,7 @@ address = "0x" 40*40HEXDIG
     ; checksum encoding specified in EIP-55
     ; where applicable (EOAs).
 
-statement = *( reserved / unreserved / " " )
+statement = 1*( reserved / unreserved / " " )
     ; The purpose is to exclude LF (line breaks).
 
 version = "1"
@@ -146,7 +146,7 @@ HEXDIG         =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 export class ParsedMessage {
 	domain: string;
 	address: string;
-	statement: string;
+	statement: string | null;
 	uri: string;
 	version: string;
 	chainId: string;

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -168,12 +168,11 @@ export class SiweMessage {
 		}
 
 		let suffix = suffixArray.join('\n');
-
+		prefix = [prefix, this.statement].join('\n\n');
 		if (this.statement) {
-			prefix = [prefix, this.statement].join('\n\n');
+			prefix += '\n'
 		}
-
-		return [prefix, suffix].join('\n\n');
+		return [prefix, suffix].join('\n');
 	}
 
 	/** @deprecated

--- a/lib/regex.ts
+++ b/lib/regex.ts
@@ -20,7 +20,7 @@ const MESSAGE = `^${DOMAIN}${ADDRESS}${STATEMENT}${URI_LINE}${VERSION}${CHAIN_ID
 export class ParsedMessage {
 	domain: string;
 	address: string;
-	statement: string;
+	statement: string | null;
 	uri: string;
 	version: string;
 	chainId: string;

--- a/test/parsing_positive.json
+++ b/test/parsing_positive.json
@@ -90,5 +90,17 @@
             "nonce": "32891757",
             "issuedAt": "2021-09-30T16:25:24.000Z"
         }
+    },
+    "no statement": {
+        "message": "service.org wants you to sign in with your Ethereum account:\n0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2\n\n\nURI: https://service.org/login\nVersion: 1\nChain ID: 1\nNonce: 32891757\nIssued At: 2021-09-30T16:25:24.000Z",
+        "fields": {
+            "domain": "service.org",
+            "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "uri": "https://service.org/login",
+            "version": "1",
+            "chainId": "1",
+            "nonce": "32891757",
+            "issuedAt": "2021-09-30T16:25:24.000Z"
+        }
     }
 }


### PR DESCRIPTION
In the ABNF grammar, I had to restrict statement to have at least one character, otherwise the parser gets confused. But I don't quite understand why, it doesn't look ambiguous to me.