### PR TITLE
feat: add expiration time, print sig-msg tuple for manual verification

### DIFF
--- a/examples/notepad/src/index.ts
+++ b/examples/notepad/src/index.ts
@@ -97,7 +97,8 @@ app.post('/api/sign_in', async (req, res) => {
         }
 
         const message = new SiweMessage(req.body.message);
-
+        console.log(message);
+        console.log(signature);
         const infuraProvider = new providers.JsonRpcProvider(
             {
                 allowGzip: true,

--- a/examples/notepad/src/providers.ts
+++ b/examples/notepad/src/providers.ts
@@ -81,6 +81,7 @@ const signIn = async (connector: Providers) => {
     /**
      * Creates the message object
      */
+    const expiration = new Date(Date.now() + 36000000);
     const message = new SiweMessage({
         domain: document.location.host,
         address,
@@ -89,12 +90,15 @@ const signIn = async (connector: Providers) => {
         version: '1',
         statement: 'SIWE Notepad Example',
         nonce,
+        expirationTime: expiration.toISOString()
     });
 
     /**
      * Generates the message to be signed and uses the provider to ask for a signature
      */
     const signature = await provider.getSigner().signMessage(message.prepareMessage());
+    console.log(message.prepareMessage());
+    console.log(signature);
 
     /**
      * Calls our sign_in endpoint to validate the message, if successful it will

--- a/examples/notepad/src/providers.ts
+++ b/examples/notepad/src/providers.ts
@@ -90,7 +90,8 @@ const signIn = async (connector: Providers) => {
         version: '1',
         statement: 'SIWE Notepad Example',
         nonce,
-        expirationTime: expiration.toISOString()
+        expirationTime: expiration.toISOString(),
+        resources: ["http://localhost:4361/me"]
     });
 
     /**


### PR DESCRIPTION
- Add extra default field to expand test use-cases
- console.log tuple so that user can generate and test manually on their platform