### PR TITLE
Update docs: fixes typographical error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Sign-In with Ethereum describes how Ethereum accounts authenticate with 
 off-chain services by signing a standard message format parameterized by scope,
 session details, and security mechanisms (e.g., a nonce). The goals of this 
-specification are to provide a self-custodied alternative to centralized 
+specification are to provide a self-custodial alternative to centralized 
 identity providers, improve interoperability across off-chain services for 
 Ethereum-based authentication, and provide wallet vendors a consistent 
 machine-readable message format to achieve improved user experiences and 


### PR DESCRIPTION
This corrects *self-custodied* to **self-custodial.**