### PR TITLE
Add tests for the validate function

### DIFF
--- a/packages/siwe/lib/client.test.ts
+++ b/packages/siwe/lib/client.test.ts
@@ -55,7 +55,15 @@ describe(`Message verification without suppressExceptions`, () => {
             domain: (test_fields as any).domainBinding,
             nonce: (test_fields as any).matchNonce,
           })
-          .then(({ success }) => success)
+          // when validate is removed uncomment this and remove the following then
+          // .then(({ success }) => success)
+          .then(async ({ data }) => {
+            jest
+              .useFakeTimers()
+              .setSystemTime(new Date((test_fields as any).time || test_fields.issuedAt));
+            const res = await msg.validate(test_fields.signature);
+            return res === data;
+          })
       ).resolves.toBeTruthy();
     }
   );


### PR DESCRIPTION
Tests the now deprecated `validate` function. Expected working code for when the function is removed is commented.