### PR TITLE
Do not regenerate api object that does not change

### DIFF
--- a/packages/siwe-parser/lib/abnf.ts
+++ b/packages/siwe-parser/lib/abnf.ts
@@ -144,6 +144,22 @@ DIGIT          =  %x30-39
 HEXDIG         =  DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 `;
 
+class GrammarApi {
+	static grammarObj = this.generateApi();
+
+	static generateApi() {
+		const api = new apgApi(GRAMMAR);
+		api.generate();
+		if (api.errors.length) {
+			console.error(api.errorsToAscii());
+			console.error(api.linesToAscii());
+			console.log(api.displayAttributeErrors());
+			throw new Error(`ABNF grammar has errors`);
+		}
+		return api.toObject();
+	}
+}
+
 export class ParsedMessage {
 	domain: string;
 	address: string;
@@ -159,16 +175,6 @@ export class ParsedMessage {
 	resources: Array<string> | null;
 
 	constructor(msg: string) {
-		const api = new apgApi(GRAMMAR);
-		api.generate();
-		if (api.errors.length) {
-			console.error(api.errorsToAscii());
-			console.error(api.linesToAscii());
-			console.log(api.displayAttributeErrors());
-			throw new Error(`ABNF grammar has errors`);
-		}
-
-		const grammarObj = api.toObject();
 		const parser = new apgLib.parser();
 		parser.ast = new apgLib.ast();
 		const id = apgLib.ids;
@@ -324,7 +330,7 @@ export class ParsedMessage {
 		};
 		parser.ast.callbacks.resources = resources;
 
-		const result = parser.parse(grammarObj, "sign-in-with-ethereum", msg);
+		const result = parser.parse(GrammarApi.grammarObj, "sign-in-with-ethereum", msg);
 		if (!result.success) {
 			throw new Error(`Invalid message: ${JSON.stringify(result)}`);
 		}


### PR DESCRIPTION
The Dynamic team is using `siwe-parser` in our codebase in production, and noticed that `ParsedMessage(text)` was causing unnecessary latency in our application. When we took a closer look its implementation, we noticed that the bulk of the latency was from creating a new `apgApi`:
```ts
const api = new apgApi(GRAMMAR);
```

Doing this in the constructor of `ParsedMessage` is unnecessary because `new apgApi(GRAMMAR)` would never actually change and that `GRAMMAR` is a static `const` declared earlier in the file. This means every time we instantiate the `ParsedMessage` class, we generate a new and unnecessary `apgApi`.

This PR removes the expensive API generation from `ParsedMessage`'s constructor and make sure we only generate the API once.

`siwe-parser`'s tests have a bunch of test cases they evaluate against to check that the parser works. Locally, I added basic time duration that looks like:
```ts
const start = new Date().getTime();
const parsedMessage = new ParsedMessage(test.message); // this line was already in parser.test.ts
const duration = new Date().getTime() - start;
console.log(`test duration[${test_name}]: ${new Date().getTime() - start}`)
```

Here are the results collected from running the test BEFORE I made the change (this was running on a M1 Max):
```
test duration[couple of optional fields]: 53
test duration[no optional field]: 35
test duration[timestamp without microseconds]: 29
test duration[domain is RFC 3986 authority with IP]: 26
test duration[domain is RFC 3986 authority with userinfo]: 25
test duration[domain is RFC 3986 authority with port]: 21
test duration[domain is localhost authority with port]: 21
test duration[domain is RFC 3986 authority with userinfo and port]: 22
test duration[no statement]: 21
test duration[domain ipv6]: 22
test duration[uri ipv6]: 22
test duration[uri ipv4]: 21
test duration[uri with port]: 21
test duration[uri ipv4 query params and fragment]: 21
test duration[chainId not 1]: 21
test duration[recovery byte starting at 0]: 21
```

And here are the results collected after the change was made:
```
test duration[couple of optional fields]: 11
test duration[no optional field]: 2
test duration[timestamp without microseconds]: 2
test duration[domain is RFC 3986 authority with IP]: 1
test duration[domain is RFC 3986 authority with userinfo]: 1
test duration[domain is RFC 3986 authority with port]: 1
test duration[domain is localhost authority with port]: 2
test duration[domain is RFC 3986 authority with userinfo and port]: 2
test duration[no statement]: 0
test duration[domain ipv6]: 1
test duration[uri ipv6]: 2
test duration[uri ipv4]: 0
test duration[uri with port]: 0
test duration[uri ipv4 query params and fragment]: 0
test duration[chainId not 1]: 0
test duration[recovery byte starting at 0]: 0
```

As you can see, the duration for instantiating the `ParsedMessage` class goes down significantly after the change - and this would translate to much lower latency in our application and the endpoint that uses this.