### PR TITLE
fix verification negative tests about signature

### DIFF
--- a/test/verification_negative.json
+++ b/test/verification_negative.json
@@ -71,9 +71,8 @@
         "nonce": "rmplqh1gf",
         "issuedAt": "2022-01-05T14:31:43.954Z",
         "chainId": 1,
-        "expirationTime": "2022-01-07T14:31:43.952Z",
-        "signature": "0x31df81dc02344c9156e6f71da46e2db624b38f8f806290d670d46492b834b2e7575cbce9f48169356cfb577b910d8e30732fcf23c1ac0021d08b945ed7ee118e1b",
-        "time": "2022-01-06T14:31:43.954Z",
+        "expirationTime": "2100-01-07T14:31:43.952Z",
+        "signature": "0x31df81dc02344c9156e6f71da46e2db624b38f8f806290d670d46492b834b2e7575cbce9f48169356cfb577b910d8e30732fcf23c1ac0021d08b945ed7ee118e1b"
     },
     "not yet valid": {
         "domain": "login.xyz",

--- a/test/verification_negative.json
+++ b/test/verification_negative.json
@@ -59,7 +59,7 @@
         "nonce": "rmplqh1gf",
         "issuedAt": "2022-01-05T14:31:43.954Z",
         "chainId": 1,
-        "expirationTime": "2022-01-07T14:31:43.952Z",
+        "expirationTime": "2100-01-07T14:31:43.952Z",
         "signature": "0xf2e8420fc1b722bf4941f5a0464f98172a758ceda5039f622e425fb69fd19b20e444bba7c9a8a8d7e2b5e453553efe7c9460be5d211abe473fc146d51bb04d0cb1b"
     },
     "wrong signature": {
@@ -72,7 +72,8 @@
         "issuedAt": "2022-01-05T14:31:43.954Z",
         "chainId": 1,
         "expirationTime": "2022-01-07T14:31:43.952Z",
-        "signature": "0x31df81dc02344c9156e6f71da46e2db624b38f8f806290d670d46492b834b2e7575cbce9f48169356cfb577b910d8e30732fcf23c1ac0021d08b945ed7ee118e1b"
+        "signature": "0x31df81dc02344c9156e6f71da46e2db624b38f8f806290d670d46492b834b2e7575cbce9f48169356cfb577b910d8e30732fcf23c1ac0021d08b945ed7ee118e1b",
+        "time": "2022-01-06T14:31:43.954Z",
     },
     "not yet valid": {
         "domain": "login.xyz",


### PR DESCRIPTION
The tests "malformed signature" and "wrong signature" were actually failing because of the expiration time, which was less than `now`, and not because of the signature. This because the expiration time check is performed before the signature check. See: https://github.com/spruceid/siwe/blob/main/packages/siwe/lib/client.ts#L259-L313

[link edited]