### PR TITLE
Refactor parser utility to use keccak hash from ethers.js

### DIFF
--- a/packages/siwe-parser/lib/utils.ts
+++ b/packages/siwe-parser/lib/utils.ts
@@ -1,12 +1,13 @@
+import { id } from '@ethersproject/hash';
+
 /**
  * This method is supposed to check if an address is conforming to EIP-55.
  * @param address Address to be checked if conforms with EIP-55.
  * @returns Either the return is or not in the EIP-55 format.
  */
 export const isEIP55Address = (address: string) => {
-    const createKeccakHash = require('keccak')
     const lowerAddress = `${address}`.toLowerCase().replace('0x', '')
-    var hash = createKeccakHash('keccak256').update(lowerAddress).digest('hex')
+    var hash = id(lowerAddress).replace('0x', '')
     var ret = '0x'
 
     for (var i = 0; i < lowerAddress.length; i++) {

--- a/packages/siwe-parser/package-lock.json
+++ b/packages/siwe-parser/package-lock.json
@@ -12,94 +12,17 @@
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "keccak": "^3.0.2"
       }
     },
     "node_modules/apg-js": {
       "version": "4.1.1",
       "license": "BSD-2-Clause"
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/keccak": {
-      "version": "3.0.2",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/uri-js": {
@@ -109,11 +32,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/valid-url": {
       "version": "1.0.9"
     }
@@ -122,59 +40,14 @@
     "apg-js": {
       "version": "4.1.1"
     },
-    "inherits": {
-      "version": "2.0.4",
-      "peer": true
-    },
-    "keccak": {
-      "version": "3.0.2",
-      "peer": true,
-      "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "node-addon-api": {
-      "version": "2.0.2",
-      "peer": true
-    },
-    "node-gyp-build": {
-      "version": "4.4.0",
-      "peer": true
-    },
     "punycode": {
       "version": "2.1.1"
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "peer": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "peer": true
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "peer": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "uri-js": {
       "version": "4.4.1",
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "peer": true
     },
     "valid-url": {
       "version": "1.0.9"

--- a/packages/siwe-parser/package.json
+++ b/packages/siwe-parser/package.json
@@ -26,9 +26,6 @@
     "uri-js": "^4.4.1",
     "valid-url": "^1.0.9"
   },
-  "peerDependencies": {
-    "keccak": "^3.0.2"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/spruceid/siwe.git"


### PR DESCRIPTION
## Problem

When signing a message in the browser for certain frontend frameworks, a reference error `keccak.js:41 Uncaught ReferenceError: Buffer is not defined in the browser console` is thrown. This happens because the `keccak` package [uses](https://github.com/cryptocoinjs/keccak/blob/742b1483f25c1ee8381894e37bef49aa53e60b6c/lib/api/keccak.js#L41-L43) a global Node API ([`Buffer`](https://nodejs.org/api/buffer.html#buffer)) that isn't available in the browser.

### Frameworks

#### Next.js
This isn't a problem in Next.js because Next.js shims with a [browser implementation](https://github.com/vercel/next.js/blob/e8408c70863b6bcd05437ff92a19194788716722/packages/next/compiled/buffer/package.json) of `Buffer`. SIWE can be implemented with no problems.

#### Remix
Remix [prefers](https://github.com/remix-run/remix/issues/2248#issuecomment-1092847237) not to shim Node globals into the browser. As a result, using `keccak` produces an `ReferenceError` for `Buffer` and requires developers to hack around in order to get SIWE to work.

## Solution

This pull request refactors the `isEIP55Address` utility to compute the keccak256 hash using the `@ethersproject/hash` package which doesn't depend on Node globals. It also removes the `keccak` peer dependency because it is no longer used. There should be no changes to the current behavior. 

The `isEIP55Address` utility now works in both browser and Node environments ✅ .
