### PR TITLE
Removes useless if check and simplify `issuedAt` assignment.

### DIFF
--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -121,10 +121,7 @@ export class SiweMessage {
 
     const suffixArray = [uriField, versionField, chainField, nonceField];
 
-    if (this.issuedAt) {
-      Date.parse(this.issuedAt);
-    }
-    this.issuedAt = this.issuedAt ? this.issuedAt : new Date().toISOString();
+    this.issuedAt = this.issuedAt || new Date().toISOString();
     suffixArray.push(`Issued At: ${this.issuedAt}`);
 
     if (this.expirationTime) {


### PR DESCRIPTION
Simplifies the attribution of the `issuedAt` value and removes useless if case.