### PR TITLE
Checks if the generated nonce is valid.

### DIFF
--- a/packages/siwe/lib/utils.ts
+++ b/packages/siwe/lib/utils.ts
@@ -42,5 +42,9 @@ export const checkContractWalletSignature = async (
  * an alphanumeric character set.
  */
 export const generateNonce = (): string => {
-  return randomStringForEntropy(96);
+  const nonce = randomStringForEntropy(96);
+  if (nonce.length < 8 || !nonce) {
+    throw new Error('Error during nonce creation.');
+  }
+  return nonce;
 };


### PR DESCRIPTION
Throws if the generated nonce has less then 8 characters and is null, undefined or an empty string.