### PR TITLE
Default value for `issuedAt`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,8 +2844,7 @@
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -11906,10 +11905,10 @@
       }
     },
     "packages/siwe": {
-      "version": "2.0.5",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spruceid/siwe-parser": "file:../siwe-parser",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -11927,15 +11926,13 @@
     },
     "packages/siwe-parser": {
       "name": "@spruceid/siwe-parser",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.1.2"
       }
     }
   },
@@ -13852,8 +13849,7 @@
     "@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "peer": true
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -14332,6 +14328,7 @@
     "@spruceid/siwe-parser": {
       "version": "file:packages/siwe-parser",
       "requires": {
+        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -19234,7 +19231,7 @@
     "siwe": {
       "version": "file:packages/siwe",
       "requires": {
-        "@spruceid/siwe-parser": "file:../siwe-parser",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
@@ -19248,6 +19245,7 @@
     "siwe-parser": {
       "version": "file:packages/siwe-parser",
       "requires": {
+        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -38,7 +38,7 @@ export class SiweMessage {
    * characters. */
   nonce: string;
   /**ISO 8601 datetime string of the current time. */
-  issuedAt: string;
+  issuedAt?: string;
   /**ISO 8601 datetime string that, if present, indicates when the signed
    * authentication message is no longer valid. */
   expirationTime?: string;

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -81,7 +81,6 @@ export class SiweMessage {
       }
     }
     this.nonce = this.nonce || generateNonce();
-    this.issuedAt = this.issuedAt || new Date().toISOString();
     this.validateMessage();
   }
 
@@ -113,6 +112,8 @@ export class SiweMessage {
     const suffixArray = [uriField, versionField, chainField, nonceField];
 
     suffixArray.push(`Issued At: ${this.issuedAt}`);
+
+    this.issuedAt = this.issuedAt || new Date().toISOString();
 
     if (this.expirationTime) {
       const expiryField = `Expiration Time: ${this.expirationTime}`;
@@ -411,8 +412,10 @@ export class SiweMessage {
     }
 
     /** `issuedAt` conforms to ISO-8601 and is a valid date. */
-    if (!isValidISO8601Date(this.issuedAt)) {
-      throw new Error(SiweErrorType.INVALID_TIME_FORMAT);
+    if(this.issuedAt) {
+      if (!isValidISO8601Date(this.issuedAt)) {
+        throw new Error(SiweErrorType.INVALID_TIME_FORMAT);
+      }
     }
 
     /** `expirationTime` conforms to ISO-8601 and is a valid date. */

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -81,6 +81,7 @@ export class SiweMessage {
       }
     }
     this.nonce = this.nonce || generateNonce();
+    this.issuedAt = this.issuedAt || new Date().toISOString();
     this.validateMessage();
   }
 
@@ -111,7 +112,6 @@ export class SiweMessage {
 
     const suffixArray = [uriField, versionField, chainField, nonceField];
 
-    this.issuedAt = this.issuedAt || new Date().toISOString();
     suffixArray.push(`Issued At: ${this.issuedAt}`);
 
     if (this.expirationTime) {

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -111,9 +111,9 @@ export class SiweMessage {
 
     const suffixArray = [uriField, versionField, chainField, nonceField];
 
-    suffixArray.push(`Issued At: ${this.issuedAt}`);
-
     this.issuedAt = this.issuedAt || new Date().toISOString();
+
+    suffixArray.push(`Issued At: ${this.issuedAt}`);
 
     if (this.expirationTime) {
       const expiryField = `Expiration Time: ${this.expirationTime}`;

--- a/packages/siwe/package-lock.json
+++ b/packages/siwe/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "siwe",
-  "version": "2.1.2",
+  "name": "@spruceid/siwe",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "siwe",
-      "version": "2.1.2",
+      "name": "@spruceid/siwe",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@spruceid/siwe-parser": "file:../siwe-parser",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -26,6 +26,7 @@
       }
     },
     "../siwe-parser": {
+      "name": "@spruceid/siwe-parser",
       "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/siwe/package.json
+++ b/packages/siwe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siwe",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Sign-In with Ethereum",
   "main": "dist/siwe.js",
   "types": "dist/siwe.d.ts",


### PR DESCRIPTION
This restores the previous behavior of creating a new message that would not require `issuedAt` to be passed, setting `new Date().toISOString()` as default. Addresses #133 .