### PR TITLE
Remove fixed dependency

### DIFF
--- a/packages/siwe/package.json
+++ b/packages/siwe/package.json
@@ -26,7 +26,7 @@
     "apg-js": "^4.1.1"
   },
   "peerDependencies": {
-    "ethers": "5.5.1"
+    "ethers": "^5.5.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `/packages/siwe/package.json` file had the `ethers` dependency as a fixed requirement (only allowing exactly v5.5.1 to be used). This is in conflict with the parent `package.json`, which allows minor-version changes (`^5.5.1`, allowing "Compatible with version" changes, meaning anything 5.x.x greater than or equal to 5.5.1). Since the latest Ethers on the v5 branch is v5.7, having the fixed requirement of v5.5.1 prevented upgrading to that.

This change adds the `^` to the child `package.json` to allow the flexibility to upgrade to later versions of the Ethers v5 library.