### PR TITLE
Adds type checking to EIP1271 Magic Value

### DIFF
--- a/packages/siwe/lib/utils.ts
+++ b/packages/siwe/lib/utils.ts
@@ -4,9 +4,12 @@ import { Contract, providers, Signer } from 'ethers';
 import type { SiweMessage } from './client';
 import { hashMessage } from './ethersCompat';
 
-const EIP1271_ABI = ["function isValidSignature(bytes32 _message, bytes _signature) public view returns (bytes4)"];
-const EIP1271_MAGICVALUE = "0x1626ba7e";
-const ISO8601 = /^(?<date>[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
+const EIP1271_ABI = [
+  'function isValidSignature(bytes32 _message, bytes _signature) public view returns (bytes4)',
+];
+const EIP1271_MAGICVALUE = '0x1626ba7e';
+const ISO8601 =
+  /^(?<date>[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
 
 /**
  * This method calls the EIP-1271 method for Smart Contract wallets
@@ -27,7 +30,7 @@ export const checkContractWalletSignature = async (
   const walletContract = new Contract(message.address, EIP1271_ABI, provider);
   const hashedMessage = hashMessage(message.prepareMessage());
   const res = await walletContract.isValidSignature(hashedMessage, signature);
-  return res == EIP1271_MAGICVALUE;
+  return res === EIP1271_MAGICVALUE;
 };
 
 /**
@@ -72,9 +75,12 @@ export const isValidISO8601Date = (inputDate: string): boolean => {
 
   /* Compare remaining fields */
   return inputMatch.groups.date === parsedInputMatch.groups.date;
-}
+};
 
-export const checkInvalidKeys = <T>(obj: T, keys: Array<keyof T>): Array<keyof T> => {
+export const checkInvalidKeys = <T>(
+  obj: T,
+  keys: Array<keyof T>
+): Array<keyof T> => {
   const invalidKeys: Array<keyof T> = [];
   Object.keys(obj).forEach(key => {
     if (!keys.includes(key as keyof T)) {
@@ -82,4 +88,4 @@ export const checkInvalidKeys = <T>(obj: T, keys: Array<keyof T>): Array<keyof T
     }
   });
   return invalidKeys;
-}
+};


### PR DESCRIPTION
This requires that the contract specifically returns the `bytes4 MAGICVALUE` with an extra type check.