### PR TITLE
Adds stricter type validation for constructor and remove defaults

### DIFF
--- a/packages/siwe-parser/lib/utils.ts
+++ b/packages/siwe-parser/lib/utils.ts
@@ -1,32 +1,33 @@
-import { keccak_256 } from '@noble/hashes/sha3';
-import { bytesToHex } from '@noble/hashes/utils';
+import { keccak_256 } from "@noble/hashes/sha3";
+import { bytesToHex } from "@noble/hashes/utils";
 /**
  * This method is supposed to check if an address is conforming to EIP-55.
  * @param address Address to be checked if conforms with EIP-55.
  * @returns Either the return is or not in the EIP-55 format.
  */
 export const isEIP55Address = (address: string) => {
-    if(address.length != 42) {
-        return false;
-    }
+  if (address.length != 42) {
+    return false;
+  }
 
-    const lowerAddress = `${address}`.toLowerCase().replace('0x', '');
-    var hash = bytesToHex(keccak_256(lowerAddress));
-    var ret = '0x';
+  const lowerAddress = `${address}`.toLowerCase().replace("0x", "");
+  var hash = bytesToHex(keccak_256(lowerAddress));
+  var ret = "0x";
 
-    for (var i = 0; i < lowerAddress.length; i++) {
-        if (parseInt(hash[i], 16) >= 8) {
-            ret += lowerAddress[i].toUpperCase();
-        } else {
-            ret += lowerAddress[i];
-        }
+  for (var i = 0; i < lowerAddress.length; i++) {
+    if (parseInt(hash[i], 16) >= 8) {
+      ret += lowerAddress[i].toUpperCase();
+    } else {
+      ret += lowerAddress[i];
     }
-    return address === ret;
-}
+  }
+  return address === ret;
+};
 
 export const parseIntegerNumber = (number: string): number => {
-    const parsed = parseInt(number);
-    if(parsed === NaN) throw new Error("Invalid number.");
-    if(parsed === Infinity) throw new Error("Invalid number.");
-    return parsed;
-  }
+  const parsed = parseInt(number);
+  if (Number.isNaN(number)) throw new Error("Invalid number.");
+  if (parsed === Number.POSITIVE_INFINITY) throw new Error("Invalid number.");
+  if (parsed === Number.NEGATIVE_INFINITY) throw new Error("Invalid number.");
+  return parsed;
+};

--- a/packages/siwe/lib/client.test.ts
+++ b/packages/siwe/lib/client.test.ts
@@ -65,7 +65,9 @@ describe(`Message verification without suppressExceptions`, () => {
           .then(async ({ data }) => {
             jest
               .useFakeTimers()
-              .setSystemTime(new Date((test_fields as any).time || test_fields.issuedAt));
+              .setSystemTime(
+                new Date((test_fields as any).time || test_fields.issuedAt)
+              );
             const res = await msg.validate(test_fields.signature);
             return res === data;
           })

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -457,7 +457,7 @@ export class SiweMessage {
     }
 
     /** Check if the nonce is alphanumeric and bigger then 8 characters */
-    if (!exists(this.nonce)) {
+    if (!exists(this.nonce) || this.nonce === '') {
       throw new SiweError(
         SiweErrorType.INVALID_NONCE,
         `Length > 8. Alphanumeric.`,

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -484,7 +484,7 @@ export class SiweMessage {
       if (this.nonce.length < 8 || nonce[0] !== this.nonce) {
         throw new SiweError(
           SiweErrorType.INVALID_NONCE,
-          `Length >= 8 (${nonce.length}). Alphanumeric.`,
+          `Length >= 8 (${this.nonce.length}). Alphanumeric.`,
           this.nonce
         );
       }

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -454,6 +454,14 @@ export class SiweMessage {
         'Any number representing a `chainId`',
         `${this.chainId}`
       );
+    } else {
+      if (!Number.isFinite(this.chainId)) {
+        throw new SiweError(
+          SiweErrorType.INVALID_CHAIN_ID,
+          'Any number representing a `chainId`',
+          `${this.chainId}`
+        );
+      }
     }
 
     /** Check if the nonce is alphanumeric and bigger then 8 characters */

--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -460,14 +460,14 @@ export class SiweMessage {
     if (!exists(this.nonce) || this.nonce === '') {
       throw new SiweError(
         SiweErrorType.INVALID_NONCE,
-        `Length > 8. Alphanumeric.`,
+        `Length >= 8. Alphanumeric.`,
         this.nonce
       );
     } else {
       if (typeof this.nonce !== 'string') {
         throw new SiweError(
           SiweErrorType.INVALID_NONCE,
-          `Length > 8. String. Alphanumeric.`,
+          `Length >= 8. String. Alphanumeric.`,
           this.nonce
         );
       }
@@ -476,7 +476,7 @@ export class SiweMessage {
       if (this.nonce.length < 8 || nonce[0] !== this.nonce) {
         throw new SiweError(
           SiweErrorType.INVALID_NONCE,
-          `Length > 8 (${nonce.length}). Alphanumeric.`,
+          `Length >= 8 (${nonce.length}). Alphanumeric.`,
           this.nonce
         );
       }

--- a/packages/siwe/lib/types.ts
+++ b/packages/siwe/lib/types.ts
@@ -30,7 +30,12 @@ export interface VerifyOpts {
   suppressExceptions?: boolean;
 
   /** Enables a custom verification function that will be ran alongside EIP-1271 check. */
-  verificationFallback?: (params: VerifyParams, opts: VerifyOpts, message: SiweMessage, EIP1271Promise: Promise<SiweResponse>) => Promise<SiweResponse>;
+  verificationFallback?: (
+    params: VerifyParams,
+    opts: VerifyOpts,
+    message: SiweMessage,
+    EIP1271Promise: Promise<SiweResponse>
+  ) => Promise<SiweResponse>;
 }
 
 export const VerifyOptsKeys: Array<keyof VerifyOpts> = [
@@ -57,14 +62,18 @@ export interface SiweResponse {
  * Interface used to return errors in SiweResponses.
  */
 export class SiweError {
-  constructor(type: SiweErrorType | string, expected?: string, received?: string) {
+  constructor(
+    type: SiweErrorType | string,
+    expected?: string,
+    received?: string
+  ) {
     this.type = type;
     this.expected = expected;
     this.received = received;
   }
 
-    /** Type of the error. */
-    type: SiweErrorType | string;
+  /** Type of the error. */
+  type: SiweErrorType | string;
 
   /** Expected value or condition to pass. */
   expected?: string;
@@ -109,6 +118,18 @@ export enum SiweErrorType {
 
   /** `version` is not 1. */
   INVALID_MESSAGE_VERSION = 'Invalid message version.',
+
+  /** `statement` is not valid. */
+  INVALID_MESSAGE_STATEMENT = 'Invalid message statement.',
+
+  /** `chainId` is not valid. */
+  INVALID_CHAIN_ID = 'Invalid chainId.',
+
+  /** `requestId` is not valid. */
+  INVALID_REQUEST_ID = 'Invalid requestId.',
+
+  /** `resources` is not valid. */
+  INVALID_RESOURCES = 'Invalid resources.',
 
   /** Thrown when some required field is missing. */
   UNABLE_TO_PARSE = 'Unable to parse the message.',

--- a/packages/siwe/lib/utils.ts
+++ b/packages/siwe/lib/utils.ts
@@ -4,9 +4,12 @@ import { Contract, providers, Signer } from 'ethers';
 import type { SiweMessage } from './client';
 import { hashMessage } from './ethersCompat';
 
-const EIP1271_ABI = ["function isValidSignature(bytes32 _message, bytes _signature) public view returns (bytes4)"];
-const EIP1271_MAGICVALUE = "0x1626ba7e";
-const ISO8601 = /^(?<date>[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
+const EIP1271_ABI = [
+  'function isValidSignature(bytes32 _message, bytes _signature) public view returns (bytes4)',
+];
+const EIP1271_MAGICVALUE = '0x1626ba7e';
+const ISO8601 =
+  /^(?<date>[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]))[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(.[0-9]+)?(([Zz])|([+|-]([01][0-9]|2[0-3]):[0-5][0-9]))$/;
 
 /**
  * This method calls the EIP-1271 method for Smart Contract wallets
@@ -72,9 +75,17 @@ export const isValidISO8601Date = (inputDate: string): boolean => {
 
   /* Compare remaining fields */
   return inputMatch.groups.date === parsedInputMatch.groups.date;
-}
+};
 
-export const checkInvalidKeys = <T>(obj: T, keys: Array<keyof T>): Array<keyof T> => {
+/**
+ * Checks if the provided object contains all keys in the provided keys array
+ * @param obj any object of type T
+ * @param keys an array of keyof T
+ */
+export const checkInvalidKeys = <T>(
+  obj: T,
+  keys: Array<keyof T>
+): Array<keyof T> => {
   const invalidKeys: Array<keyof T> = [];
   Object.keys(obj).forEach(key => {
     if (!keys.includes(key as keyof T)) {
@@ -82,4 +93,21 @@ export const checkInvalidKeys = <T>(obj: T, keys: Array<keyof T>): Array<keyof T
     }
   });
   return invalidKeys;
-}
+};
+
+/**
+ * A function to assert if given value is null or undefined
+ * @param value any value to have it's existence checked
+ * @returns A boolean containing the result of the validation
+ */
+export const exists = (value: any): boolean => {
+  if (value === null) {
+    return false;
+  }
+
+  if (value === undefined) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
This adds stricter type field validation for `SiweMessage` being constructed, and also removes default field assignments to `chainId`, `nonce`, and `version`, making these fields mandatory.

This depends on #161 