### PR TITLE
fix: siwe-parcel-compatibility

### DIFF
--- a/packages/siwe/lib/client.ts
+++ b/packages/siwe/lib/client.ts
@@ -4,11 +4,9 @@ import {
   ParsedMessage,
   parseIntegerNumber,
 } from '@spruceid/siwe-parser';
-// @ts-expect-error -- ethers v6 compatibility hack
-import { providers } from 'ethers';
 import * as uri from 'valid-url';
 
-import { getAddress, verifyMessage } from './ethersCompat';
+import { getAddress, Provider, verifyMessage } from './ethersCompat';
 import {
   SiweError,
   SiweErrorType,
@@ -194,7 +192,7 @@ export class SiweMessage {
    * @param signature Signature to match the address in the message.
    * @param provider Ethers provider to be used for EIP-1271 validation
    */
-  async validate(signature: string, provider?: providers.Provider) {
+  async validate(signature: string, provider?: Provider) {
     console.warn(
       'validate() has been deprecated, please update your code to use verify(). validate() may be removed in future versions.'
     );

--- a/packages/siwe/lib/ethersCompat.ts
+++ b/packages/siwe/lib/ethersCompat.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 type Ethers6BigNumberish = string | number | bigint;
 
 // NB: This compatibility type omits the `Signature` class defined in ethers v6;
@@ -31,21 +33,23 @@ let ethersHashMessage = null;
 let ethersGetAddress = null;
 
 try {
-  const { utils } = require('ethers');
-  ethersVerifyMessage = utils.verifyMessage;
-  ethersHashMessage = utils.hashMessage;
-  ethersGetAddress = utils.getAddress;
-} catch (error) {
-  const { verifyMessage, getAddress, hashMessage } = require('ethers');
-
-  ethersVerifyMessage = verifyMessage as (
+  // @ts-expect-error -- v6 compatibility hack
+  ethersVerifyMessage = ethers.utils.verifyMessage;
+  // @ts-expect-error -- v6 compatibility hack
+  ethersHashMessage = ethers.utils.hashMessage;
+  // @ts-expect-error -- v6 compatibility hack
+  ethersGetAddress = ethers.utils.getAddress;
+} catch {
+  ethersVerifyMessage = ethers.verifyMessage as (
     message: Uint8Array | string,
     sig: Ethers6SignatureLike
   ) => string;
 
-  ethersHashMessage = hashMessage as (message: Uint8Array | string) => string;
+  ethersHashMessage = ethers.hashMessage as (
+    message: Uint8Array | string
+  ) => string;
 
-  ethersGetAddress = getAddress as (address: string) => string;
+  ethersGetAddress = ethers.getAddress as (address: string) => string;
 }
 
 export const verifyMessage = ethersVerifyMessage;

--- a/packages/siwe/lib/ethersCompat.ts
+++ b/packages/siwe/lib/ethersCompat.ts
@@ -1,5 +1,3 @@
-import ethers from 'ethers';
-
 type Ethers6BigNumberish = string | number | bigint;
 
 // NB: This compatibility type omits the `Signature` class defined in ethers v6;
@@ -7,41 +5,49 @@ type Ethers6BigNumberish = string | number | bigint;
 type Ethers6SignatureLike =
   | string
   | {
-    r: string;
-    s: string;
-    v: Ethers6BigNumberish;
-    yParity?: 0 | 1;
-    yParityAndS?: string;
-  }
+      r: string;
+      s: string;
+      v: Ethers6BigNumberish;
+      yParity?: 0 | 1;
+      yParityAndS?: string;
+    }
   | {
-    r: string;
-    yParityAndS: string;
-    yParity?: 0 | 1;
-    s?: string;
-    v?: number;
-  }
+      r: string;
+      yParityAndS: string;
+      yParity?: 0 | 1;
+      s?: string;
+      v?: number;
+    }
   | {
-    r: string;
-    s: string;
-    yParity: 0 | 1;
-    v?: Ethers6BigNumberish;
-    yParityAndS?: string;
-  };
+      r: string;
+      s: string;
+      yParity: 0 | 1;
+      v?: Ethers6BigNumberish;
+      yParityAndS?: string;
+    };
 
-export const verifyMessage =
-  // @ts-expect-error -- ethers v6 compatibility hack
-  ethers?.utils.verifyMessage ??
-  (ethers?.verifyMessage as (
+let ethersVerifyMessage = null;
+let ethersHashMessage = null;
+let ethersGetAddress = null;
+
+try {
+  const { utils } = require('ethers');
+  ethersVerifyMessage = utils.verifyMessage;
+  ethersHashMessage = utils.hashMessage;
+  ethersGetAddress = utils.getAddress;
+} catch (error) {
+  const { verifyMessage, getAddress, hashMessage } = require('ethers');
+
+  ethersVerifyMessage = verifyMessage as (
     message: Uint8Array | string,
     sig: Ethers6SignatureLike
-  ) => string);
+  ) => string;
 
-export const hashMessage =
-  // @ts-expect-error -- ethers v6 compatibility hack
-  ethers.utils?.hashMessage ??
-  (ethers?.hashMessage as (message: Uint8Array | string) => string);
+  ethersHashMessage = hashMessage as (message: Uint8Array | string) => string;
 
-export const getAddress =
-  // @ts-expect-error -- ethers v6 compatibility hack
-  ethers.utils?.getAddress ??
-  (ethers?.getAddress as (address: string) => string);
+  ethersGetAddress = getAddress as (address: string) => string;
+}
+
+export const verifyMessage = ethersVerifyMessage;
+export const hashMessage = ethersHashMessage;
+export const getAddress = ethersGetAddress;

--- a/packages/siwe/lib/ethersCompat.ts
+++ b/packages/siwe/lib/ethersCompat.ts
@@ -1,10 +1,4 @@
-import {
-  // @ts-expect-error -- ethers v6 compatibility hack
-  utils,
-  verifyMessage as ethersVerifyMessage,
-  hashMessage as ethersHashMessage,
-  getAddress as ethersGetAddress,
-} from 'ethers';
+import ethers from 'ethers';
 
 type Ethers6BigNumberish = string | number | bigint;
 
@@ -13,37 +7,41 @@ type Ethers6BigNumberish = string | number | bigint;
 type Ethers6SignatureLike =
   | string
   | {
-    r: string;
-    s: string;
-    v: Ethers6BigNumberish;
-    yParity?: 0 | 1;
-    yParityAndS?: string;
-  }
+      r: string;
+      s: string;
+      v: Ethers6BigNumberish;
+      yParity?: 0 | 1;
+      yParityAndS?: string;
+    }
   | {
-    r: string;
-    yParityAndS: string;
-    yParity?: 0 | 1;
-    s?: string;
-    v?: number;
-  }
+      r: string;
+      yParityAndS: string;
+      yParity?: 0 | 1;
+      s?: string;
+      v?: number;
+    }
   | {
-    r: string;
-    s: string;
-    yParity: 0 | 1;
-    v?: Ethers6BigNumberish;
-    yParityAndS?: string;
-  };
+      r: string;
+      s: string;
+      yParity: 0 | 1;
+      v?: Ethers6BigNumberish;
+      yParityAndS?: string;
+    };
 
 export const verifyMessage =
-  utils?.verifyMessage ??
-  (ethersVerifyMessage as (
+  // @ts-expect-error -- ethers v6 compatibility hack
+  ethers?.utils.verifyMessage ??
+  (ethers?.verifyMessage as (
     message: Uint8Array | string,
     sig: Ethers6SignatureLike
   ) => string);
 
 export const hashMessage =
-  utils?.hashMessage ??
-  (ethersHashMessage as (message: Uint8Array | string) => string);
+  // @ts-expect-error -- ethers v6 compatibility hack
+  ethers.utils?.hashMessage ??
+  (ethers?.hashMessage as (message: Uint8Array | string) => string);
 
 export const getAddress =
-  utils?.getAddress ?? (ethersGetAddress as (address: string) => string);
+  // @ts-expect-error -- ethers v6 compatibility hack
+  ethers.utils?.getAddress ??
+  (ethers?.getAddress as (address: string) => string);

--- a/packages/siwe/lib/ethersCompat.ts
+++ b/packages/siwe/lib/ethersCompat.ts
@@ -7,26 +7,26 @@ type Ethers6BigNumberish = string | number | bigint;
 type Ethers6SignatureLike =
   | string
   | {
-      r: string;
-      s: string;
-      v: Ethers6BigNumberish;
-      yParity?: 0 | 1;
-      yParityAndS?: string;
-    }
+    r: string;
+    s: string;
+    v: Ethers6BigNumberish;
+    yParity?: 0 | 1;
+    yParityAndS?: string;
+  }
   | {
-      r: string;
-      yParityAndS: string;
-      yParity?: 0 | 1;
-      s?: string;
-      v?: number;
-    }
+    r: string;
+    yParityAndS: string;
+    yParity?: 0 | 1;
+    s?: string;
+    v?: number;
+  }
   | {
-      r: string;
-      s: string;
-      yParity: 0 | 1;
-      v?: Ethers6BigNumberish;
-      yParityAndS?: string;
-    };
+    r: string;
+    s: string;
+    yParity: 0 | 1;
+    v?: Ethers6BigNumberish;
+    yParityAndS?: string;
+  };
 
 export const verifyMessage =
   // @ts-expect-error -- ethers v6 compatibility hack

--- a/packages/siwe/lib/ethersCompat.ts
+++ b/packages/siwe/lib/ethersCompat.ts
@@ -5,26 +5,26 @@ type Ethers6BigNumberish = string | number | bigint;
 type Ethers6SignatureLike =
   | string
   | {
-      r: string;
-      s: string;
-      v: Ethers6BigNumberish;
-      yParity?: 0 | 1;
-      yParityAndS?: string;
-    }
+    r: string;
+    s: string;
+    v: Ethers6BigNumberish;
+    yParity?: 0 | 1;
+    yParityAndS?: string;
+  }
   | {
-      r: string;
-      yParityAndS: string;
-      yParity?: 0 | 1;
-      s?: string;
-      v?: number;
-    }
+    r: string;
+    yParityAndS: string;
+    yParity?: 0 | 1;
+    s?: string;
+    v?: number;
+  }
   | {
-      r: string;
-      s: string;
-      yParity: 0 | 1;
-      v?: Ethers6BigNumberish;
-      yParityAndS?: string;
-    };
+    r: string;
+    s: string;
+    yParity: 0 | 1;
+    v?: Ethers6BigNumberish;
+    yParityAndS?: string;
+  };
 
 let ethersVerifyMessage = null;
 let ethersHashMessage = null;

--- a/packages/siwe/lib/ethersCompat.ts
+++ b/packages/siwe/lib/ethersCompat.ts
@@ -52,6 +52,11 @@ try {
   ethersGetAddress = ethers.getAddress as (address: string) => string;
 }
 
+// @ts-expect-error -- v6 compatibility hack
+type ProviderV5 = ethers.providers.Provider
+type ProviderV6 = ethers.Provider
+
+export type Provider = ProviderV6 extends undefined ? ProviderV5 : ProviderV6
 export const verifyMessage = ethersVerifyMessage;
 export const hashMessage = ethersHashMessage;
 export const getAddress = ethersGetAddress;


### PR DESCRIPTION
## Context
Siwe fails to build when using with parcel bundler. 

If using `ethers v5`,
Parcel expects` import {verifyMessage} from "ethers"` to resolve, and fails to build

<img width="823" alt="Screenshot 2024-04-11 at 3 36 18 PM" src="https://github.com/spruceid/siwe/assets/51452848/bae576c7-9f76-4394-8571-aea01c042401">

If using `ethers v6`,
Parcel expects `import {utils} from "ethers" `to resolve and fails to build

<img width="819" alt="Screenshot 2024-04-11 at 3 39 32 PM" src="https://github.com/spruceid/siwe/assets/51452848/84b825be-a27d-4273-8550-5f6b08178674">

## Minimal Reproduction 
https://codesandbox.io/p/devbox/shy-morning-jvjffk-forked-jw8vcj

Steps:
- yarn 
- yarn build

## Solution 
Use try catch to handle the error and export the functions [verifyMessage, hashMessage, getAddress] based on ethers version
All tests passing ✅ 

```
let ethersVerifyMessage = null;
let ethersHashMessage = null;
let ethersGetAddress = null;

try {
  const { utils } = require('ethers');
  ethersVerifyMessage = utils.verifyMessage;
  ethersHashMessage = utils.hashMessage;
  ethersGetAddress = utils.getAddress;
} catch (error) {
  const { verifyMessage, getAddress, hashMessage } = require('ethers');

  ethersVerifyMessage = verifyMessage as (
    message: Uint8Array | string,
    sig: Ethers6SignatureLike
  ) => string;

  ethersHashMessage = hashMessage as (message: Uint8Array | string) => string;

  ethersGetAddress = getAddress as (address: string) => string;
}

export const verifyMessage = ethersVerifyMessage;
export const hashMessage = ethersHashMessage;
export const getAddress = ethersGetAddress;
```


