### PR TITLE
build: npm bump update apg-js ^4.1.1 -> ^4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14622,7 +14622,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
+        "apg-js": "^4.3.0",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
       },
@@ -17395,7 +17395,7 @@
         "@noble/hashes": "^1.1.2",
         "@typescript-eslint/eslint-plugin": "^5.23.0",
         "@typescript-eslint/parser": "^5.23.0",
-        "apg-js": "^4.1.1",
+        "apg-js": "^4.3.0",
         "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "prettier": "^2.6.2",

--- a/packages/siwe-parser/package.json
+++ b/packages/siwe-parser/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@noble/hashes": "^1.1.2",
-    "apg-js": "^4.1.1",
+    "apg-js": "^4.3.0",
     "uri-js": "^4.4.1",
     "valid-url": "^1.0.9"
   },


### PR DESCRIPTION
As mentioned by @tommasini in https://github.com/MetaMask/metamask-mobile/pull/9247#discussion_r1568021124, there was a bug in an older version of the `apg-js` npm package. 

There was a fix released in `apg-js` version 4.2.0 ([see #165 comment](https://github.com/spruceid/siwe/issues/165#issuecomment-1686341772)) to fix the `thisThis` reference from `apg-js/src/apg-conv-api/transformers.js` wrapped by jest. 

This PR updates the `apg-js` npm package in `packages/siwe-parser` to include the fix mentioned in https://github.com/spruceid/siwe/issues/165

Related:
https://github.com/ldthomas/apg-js?tab=readme-ov-file#430-release-notes
https://github.com/ldthomas/apg-js?tab=readme-ov-file#420-release-notes