### PR TITLE
chore(EIP55): optional EIP55 validation

### DIFF
--- a/packages/siwe-parser/lib/abnf.ts
+++ b/packages/siwe-parser/lib/abnf.ts
@@ -175,7 +175,7 @@ export class ParsedMessage {
 	requestId: string | null;
 	resources: Array<string> | null;
 
-	constructor(msg: string) {
+	constructor(msg: string, parserOptions = { validateEIP55Address: true }) {
 		const parser = new apgLib.parser();
 		parser.ast = new apgLib.ast();
 		const id = apgLib.ids;
@@ -359,7 +359,7 @@ export class ParsedMessage {
 			throw new Error("Domain cannot be empty.");
 		}
 
-		if (!isEIP55Address(this.address)) {
+		if (parserOptions.validateEIP55Address && !isEIP55Address(this.address)) {
 			throw new Error("Address not conformant to EIP-55.");
 		}
 	}

--- a/packages/siwe/lib/types.ts
+++ b/packages/siwe/lib/types.ts
@@ -121,3 +121,8 @@ export enum SiweErrorType {
   /** Thrown when some required field is missing. */
   UNABLE_TO_PARSE = 'Unable to parse the message.',
 }
+
+export interface SiweMessageConstructorOptions { 
+  /** If the library should validate the address against EIP-55, defaults to true */
+  validateEIP55Address?: boolean
+}


### PR DESCRIPTION
### Context

The SIWE message constructor throws if the address isn't EIP55 compliant, which brakes the SIWE integration for users that use wallets such as Zerion.

In addition to that, it's not a hard requirement based on the[ EIP-4361 spec](https://eips.ethereum.org/EIPS/eip-4361)
> address REQUIRED. The Ethereum address performing the signing. Its value SHOULD be conformant to mixed-case checksum address encoding specified in [ERC-55](https://eips.ethereum.org/EIPS/eip-55) where applicable.

This provides flexibility to developers to decide whatever or not they want explicit EIP55 validation.

The option defaults to `true` and is optional for backwards compatibility.
